### PR TITLE
[US-15] Changes for the docker env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY package.json yarn.lock ./
+COPY package.json ./
 RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
@@ -38,6 +38,6 @@ ENV PORT 3000
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry.
-# ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED 1
 
 CMD ["node_modules/.bin/next", "start"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ docker build -t jokr-front-img .
 Step 2 - Run the previous image mapping ports 3000
 
 ```bash
-docker run -rm -p 3000:3000 jokr-front-img
+docker run -p 3000:3000 jokr-front-img
 ```
 
 On changes repeat the 1st and 2nd Step

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 Step 1 - Build the project inside a Docker Image
 
 ```bash
-docker build -t nextjs-docker .
+docker build -t jokr-front-img .
 ```
 
 Step 2 - Run the previous image mapping ports 3000
 
 ```bash
-docker run -p 3000:3000 nextjs-docker
+docker run -rm -p 3000:3000 jokr-front-img
 ```
 
 On changes repeat the 1st and 2nd Step

--- a/README.md
+++ b/README.md
@@ -1,57 +1,17 @@
-# With Docker
+# Usage
 
-This examples shows how to use Docker with Next.js based on the [deployment documentation](https://nextjs.org/docs/deployment#docker-image). Additionally, it contains instructions for deploying to Google Cloud Run. However, you can use any container-based deployment host.
+## With the Dockerfile
 
-## How to use
-
-Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+Step 1 - Build the project inside a Docker Image
 
 ```bash
-npx create-next-app --example with-docker nextjs-docker
-# or
-yarn create next-app --example with-docker nextjs-docker
+docker build -t nextjs-docker .
 ```
 
-## Using Docker
-
-1. [Install Docker](https://docs.docker.com/get-docker/) on your machine.
-1. Build your container: `docker build -t nextjs-docker .`.
-1. Run your container: `docker run -p 3000:3000 nextjs-docker`.
-
-You can view your images created with `docker images`.
-
-## Deploying to Google Cloud Run
-
-The `start` script in `package.json` has been modified to accept a `PORT` environment variable (for compatibility with Google Cloud Run).
-
-1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) so you can use `gcloud` on the command line.
-1. Run `gcloud auth login` to log in to your account.
-1. [Create a new project](https://cloud.google.com/run/docs/quickstarts/build-and-deploy) in Google Cloud Run (e.g. `nextjs-docker`). Ensure billing is turned on.
-1. Build your container image using Cloud Build: `gcloud builds submit --tag gcr.io/PROJECT-ID/helloworld --project PROJECT-ID`. This will also enable Cloud Build for your project.
-1. Deploy to Cloud Run: `gcloud run deploy --image gcr.io/PROJECT-ID/helloworld --project PROJECT-ID --platform managed`. Choose a region of your choice.
-
-   - You will be prompted for the service name: press Enter to accept the default name, `helloworld`.
-   - You will be prompted for [region](https://cloud.google.com/run/docs/quickstarts/build-and-deploy#follow-cloud-run): select the region of your choice, for example `us-central1`.
-   - You will be prompted to **allow unauthenticated invocations**: respond `y`.
-
-Or click the button below, authorize the script, and select the project and region when prompted:
-
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run/?git_repo=https://github.com/vercel/next.js.git&dir=examples/with-docker)
-
-## Running Locally
-
-First, run the development server:
+Step 2 - Run the previous image mapping ports 3000
 
 ```bash
-npm run dev
-# or
-yarn dev
+docker run -p 3000:3000 nextjs-docker
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
-
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
-
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+On changes repeat the 1st and 2nd Step


### PR DESCRIPTION
## What?
The previous Dockerfile had errors involving the build for the entire front-end project thanks to the requirement of a yarn.lock file.

## Why?
Developers had problems building an Image based on the past Dockerfile.

## Testing / Proof
The index at http://localhost:3000.
![image](https://user-images.githubusercontent.com/44516996/141201106-e4470164-a93f-4fd7-be5b-40d1ecef603f.png)

The image running
![image](https://user-images.githubusercontent.com/44516996/141201197-f08c82a4-8da0-4553-9fd0-3325c2d8ea1c.png)

## How can this change be undone in case of failure?
Go back to the versions of the Dockerfile to run the last versions.

ping @fullstack-bootcamp-2021
