### PR TITLE
[US-29] Base config file for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: circleci/node:14.0-buster
+    steps:
+      - checkout
+      - run:
+          name: Update NPM
+          command: "sudo npm install -g npm@5"
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Install Dependencies
+          command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,10 @@
-# Install dependencies only when needed
-FROM node:14-alpine AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
-WORKDIR /app
-COPY package.json ./
-RUN yarn install --frozen-lockfile
+FROM node:14-alpine
 
-# Rebuild the source code only when needed
-FROM node:14-alpine AS builder
 WORKDIR /app
 COPY . .
-COPY --from=deps /app/node_modules ./node_modules
-RUN yarn build
 
-# Production image, copy all the files and run next
-FROM node:14-alpine AS runner
-WORKDIR /app
-
-ENV NODE_ENV production
-
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
-
-# You only need to copy next.config.js if you are NOT using the default configuration
-# COPY --from=builder /app/next.config.js ./
-COPY --from=builder /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./package.json
-
-USER nextjs
-
+RUN npm install
 EXPOSE 3000
 
-ENV PORT 3000
-
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry.
 ENV NEXT_TELEMETRY_DISABLED 1
-
-CMD ["node_modules/.bin/next", "start"]
+ENTRYPOINT ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker build -t jokr-front-img .
 Step 2 - Run the previous image mapping ports 3000
 
 ```bash
-docker run -p 3000:3000 jokr-front-img
+docker run --rm -p 3000:3000 jokr-front-img
 ```
 
 On changes repeat the 1st and 2nd Step


### PR DESCRIPTION
## What?
This PR just adds the base config file to work with Circle CI.

## Why?
To automate the process of building and testing the app on Circle CI.

## Testing / Proof
No proof until is uploaded to Circle CI.

## How can this change be undone in case of failure?
Change the Circle CI file into a more simple version.

ping @fullstack-bootcamp-2021
