### PR TITLE
[US-33] Docker build and push on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ workflows:
   version: 2
   app-docker-push:
     jobs:
-      - build:
+      - build
       - docker-build:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,12 @@ workflows:
       - docker-build:
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - publish-latest:
           requires:
             - docker-build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,10 @@
 version: 2.1
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: pacodevs/jokr-front
+    docker:
+      - image: circleci/buildpack-deps:stretch
 jobs:
   build:
     docker:
@@ -20,3 +26,50 @@ jobs:
       - run:
           name: Run Tests
           command: npm run test
+  docker-build:
+    executor: docker-publisher
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t $IMAGE_NAME:latest .
+      - run:
+          name: Archive Docker image
+          command: docker save -o image.tar $IMAGE_NAME
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./image.tar
+  publish-latest:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker push $IMAGE_NAME:latest
+workflows:
+  version: 2
+  app-docker-push:
+    jobs:
+      - build:
+      - docker-build:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - publish-latest:
+          requires:
+            - docker-build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,12 @@ workflows:
       - docker-build:
           requires:
             - build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - publish-latest:
           requires:
             - docker-build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master


### PR DESCRIPTION
## What?
Now CircleCI has the ability to build and push a docker image to a public registry, in this case to Docker Hub.

## Why?
To enable the next step that is Continuous Delivery for both projects based on images from the master branch.

## Testing / Proof
Proof of the docker image published on docker hub.
![image](https://user-images.githubusercontent.com/44516996/143301019-aa79df03-53c4-464f-9aae-cb7368a1bb8a.png)

## How can this change be undone in case of failure?
Remove the added lines on the .circleci/config.yml to avoid building and pushing the new docker image.

ping @fullstack-bootcamp-2021
