### PR TITLE
[US-40] CircleCI fix for docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,12 @@ workflows:
       - docker-build:
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - publish-latest:
           requires:
             - docker-build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,12 @@ workflows:
       - docker-build:
           requires:
             - build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - publish-latest:
           requires:
             - docker-build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ FROM node:14-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY package.json ./
-RUN yarn install --frozen-lockfile
+RUN npm install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM node:14-alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
-RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
+RUN npm run build && npm install --production --ignore-scripts --prefer-offline
 
 # Production image, copy all the files and run next
 FROM node:14-alpine AS runner
@@ -37,4 +37,4 @@ ENV PORT 3000
 
 ENV NEXT_TELEMETRY_DISABLED 1
 
-CMD ["node_modules/.bin/next", "start"]
+CMD ["npm", "run","start"]


### PR DESCRIPTION
## What?
A change for the Dockerfile that was made to work with "npm" instead of "yarn".

## Why?
The last version that worked with only "yarn" failed while trying to build the image on CircleCI.

## Testing / Proof
Screenshot of the commit on CircleCI working completely.
![image](https://user-images.githubusercontent.com/44516996/144933051-2f3b0334-764c-4c33-a137-fe939304af75.png)

## How can this change be undone in case of failure?
Return to use yarn instead of npm.

ping @fullstack-bootcamp-2021
