### PR TITLE
[US-42] Heroku deploy on merge from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,18 +85,18 @@ workflows:
       - docker-build:
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - publish-latest:
           requires:
             - docker-build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - heroku-release:
           requires:
             - publish-latest
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,14 +61,14 @@ jobs:
           command: docker load -i /tmp/workspace/image.tar
       - run:
           name: Tag image for Heroku push
-          command: docker tag $IMAGE_NAME:latest $HEROKU_IMAGE:release
+          command: docker tag $IMAGE_NAME:latest $HEROKU_IMAGE:latest
       - run:
           name: Push Docker image to Heroku
           command: |
             set -x
             sudo curl https://cli-assets.heroku.com/install.sh | sh
             HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:login
-            docker push $HEROKU_IMAGE:release
+            docker push $HEROKU_IMAGE:latest
             HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:release -a jokr-front web
 executors:
   docker-publisher:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,4 @@
 version: 2.1
-executors:
-  docker-publisher:
-    environment:
-      IMAGE_NAME: pacodevs/jokr-front
-    docker:
-      - image: circleci/buildpack-deps:stretch
 jobs:
   build:
     docker:
@@ -56,38 +50,53 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push $IMAGE_NAME:latest
-  heroku-deploy:
-      machine: true
-      steps:
-        - checkout
-        - run:
-            name: Build and push Docker image to Heroku
-            command: |
-              set -x
-              sudo curl https://cli-assets.heroku.com/install.sh | sh
-              HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:login
-              HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:push -a jokr-front web
-              HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:release -a jokr-front web
+  heroku-release:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.
+      - run:
+          name: Tag image for Heroku push
+          command: docker tag $IMAGE_NAME:latest $HEROKU_IMAGE:release
+      - run:
+          name: Push Docker image to Heroku
+          command: |
+            set -x
+            sudo curl https://cli-assets.heroku.com/install.sh | sh
+            HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:login
+            docker push $HEROKU_IMAGE:release
+            HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:release -a jokr-front web
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: pacodevs/jokr-front
+      HEROKU_IMAGE: registry.heroku.com/jokr-front/web
+    docker:
+      - image: circleci/buildpack-deps:stretch
 workflows:
   version: 2
   app-docker-push:
     jobs:
       - build
-      # - docker-build:
-      #     requires:
-      #       - build
-      #     # filters:
-      #     #   branches:
-      #     #     only: master
-      # - publish-latest:
-      #     requires:
-      #       - docker-build
-      #     # filters:
-      #     #   branches:
-      #     #     only: master
-      - heroku-deploy:
+      - docker-build:
           requires:
             - build
+          # filters:
+          #   branches:
+          #     only: master
+      - publish-latest:
+          requires:
+            - docker-build
+          # filters:
+          #   branches:
+          #     only: master
+      - heroku-release:
+          requires:
+            - publish-latest
           # filters:
           #   branches:
           #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,20 +56,38 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push $IMAGE_NAME:latest
+  heroku-deploy:
+      machine: true
+      steps:
+        - checkout
+        - run:
+            name: Build and push Docker image to Heroku
+            command: |
+              set -x
+              sudo curl https://cli-assets.heroku.com/install.sh | sh
+              HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:login
+              HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:push -a jokr-front web
+              HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:release -a jokr-front web
 workflows:
   version: 2
   app-docker-push:
     jobs:
       - build
-      - docker-build:
+      # - docker-build:
+      #     requires:
+      #       - build
+      #     # filters:
+      #     #   branches:
+      #     #     only: master
+      # - publish-latest:
+      #     requires:
+      #       - docker-build
+      #     # filters:
+      #     #   branches:
+      #     #     only: master
+      - heroku-deploy:
           requires:
             - build
-          filters:
-            branches:
-              only: master
-      - publish-latest:
-          requires:
-            - docker-build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,12 @@ workflows:
       - docker-build:
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - publish-latest:
           requires:
             - docker-build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Load archived Docker image
-          command: docker load -i /tmp/workspace/image.
+          command: docker load -i /tmp/workspace/image.tar
       - run:
           name: Tag image for Heroku push
           command: docker tag $IMAGE_NAME:latest $HEROKU_IMAGE:release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,12 @@ workflows:
       - docker-build:
           requires:
             - build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - publish-latest:
           requires:
             - docker-build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,6 @@ COPY --from=builder /app/package.json ./package.json
 
 USER nextjs
 
-EXPOSE 3000
-
-ENV PORT 3000
-
 ENV NEXT_TELEMETRY_DISABLED 1
 
-CMD ["npm", "run","start"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## What?
Changes on the .circleci/config.yml file to allow CircleCI to send a docker image built from a Dockerfile to be deployed after each PR is accepted and a merge to master is ready.

## Why?
To start the CD cycle within both projects, by first hosting both apps separately and then bringing them together.

## Testing / Proof
Screenshot of how the front-end app is working on Heroku.
![image](https://user-images.githubusercontent.com/44516996/145082833-7b1bbe27-152f-4dcf-8567-0b3e35f70a84.png)

## How can this change be undone in case of failure?
Remove the last job in the .circleci/config.yml file going back to only push the image to docker hub.

ping @fullstack-bootcamp-2021
