### PR TITLE
[US-42] Change to remove Heroku from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,31 +50,10 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push $IMAGE_NAME:latest
-  heroku-release:
-    executor: docker-publisher
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - setup_remote_docker
-      - run:
-          name: Load archived Docker image
-          command: docker load -i /tmp/workspace/image.tar
-      - run:
-          name: Tag image for Heroku push
-          command: docker tag $IMAGE_NAME:latest $HEROKU_IMAGE:latest
-      - run:
-          name: Push Docker image to Heroku
-          command: |
-            set -x
-            sudo curl https://cli-assets.heroku.com/install.sh | sh
-            HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:login
-            docker push $HEROKU_IMAGE:latest
-            HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:release -a jokr-front web
 executors:
   docker-publisher:
     environment:
       IMAGE_NAME: pacodevs/jokr-front
-      HEROKU_IMAGE: registry.heroku.com/jokr-front/web
     docker:
       - image: circleci/buildpack-deps:stretch
 workflows:
@@ -91,12 +70,6 @@ workflows:
       - publish-latest:
           requires:
             - docker-build
-          filters:
-            branches:
-              only: master
-      - heroku-release:
-          requires:
-            - publish-latest
           filters:
             branches:
               only: master


### PR DESCRIPTION
## What?
Change to eliminate the Heroku deploy from the CircleCI jobs.

## Why?
The front app is no longer hosted on Heroku, now it is hosted on Vercel.

## Testing / Proof
Proof of the app working.
![image](https://user-images.githubusercontent.com/44516996/146229830-9faa6808-f9de-4d48-b08c-cdee50a7a372.png)

## How can this change be undone in case of failure?
Bring back the previous version of the .circleci/config.yml.

ping @fullstack-bootcamp-2021
