### PR TITLE
[US-55] Code Coverage Report and Threshold at 0%

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ jobs:
             - ./node_modules
       - run:
           name: Run Tests
-          command: npm run test
+          command: npm run test:ci
+      - store_artifacts:
+          path: coverage
   docker-build:
     executor: docker-publisher
     steps:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start -p ${PORT:=3000}",
     "test": "jest --env=jsdom",
-    "test:ci": "jest --env=jsdom --collectCoverage=true"
+    "test:ci": "jest --env=jsdom --collectCoverage=true --collectCoverageFrom pages/**/*.{js,jsx,ts,tsx}"
   },
   "dependencies": {
     "@emotion/react": "^11.6.0",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "verbose": true,
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80,
-        "statements": 80
+        "branches": 0,
+        "functions": 0,
+        "lines": 0,
+        "statements": 0
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start -p ${PORT:=3000}",
-    "test": "jest --env=jsdom"
+    "test": "jest --env=jsdom",
+    "test:ci": "jest --env=jsdom --collectCoverage=true"
   },
   "dependencies": {
     "@emotion/react": "^11.6.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
     "typescript": "^4.4.4"
   },
   "jest": {
-    "verbose": true
+    "verbose": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
+      }
+    }
   }
 }


### PR DESCRIPTION
## What?
Implementation of Code Coverage in CircleCI by adding it to Jest and setting a threshold of 0% at the moment, waiting to raise that up to around 70% to 80% in total.

## Why?
To preserve a well-maintained product around all changes that go through by making a way to **report** and **verify** the number of lines covered by unit testing.

## Testing / Proof
After each build job on CircleCI developers can review Code Coverage reports by entering the job and then selecting the tab of "Artifacts" to finally enter the "coverage/lcov-report/index.html" file. 
![image](https://user-images.githubusercontent.com/44516996/147299858-2ca0395e-59c4-430f-887c-75fa1272bd09.png)

Another way to see the report is to enter the following link: https://134-426323182-gh.circle-artifacts.com/0/coverage/lcov-report/index.html and change the first number for the number of the testing job (which, in this case, was 134).

## How can this change be undone in case of failure?
The possible error to be found in the future is that the minimum threshold is not being covered and the addition of new unit tests.

ping @fullstack-bootcamp-2021
